### PR TITLE
Add preference to choose tab close button removal scope

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -1,3 +1,11 @@
-image.tab-close-button {
-  display: none !important;
+@media (-moz-pref("mod.remove-tab-x.scope", "all")) {
+    image.tab-close-button {
+        display: none !important;
+    }
+}
+
+@media (-moz-pref("mod.remove-tab-x.scope", "pinned")) {
+    .zen-workspace-pinned-tabs-section image.tab-close-button {
+        display: none !important;
+    }
 }

--- a/preferences.json
+++ b/preferences.json
@@ -1,0 +1,12 @@
+[
+  {
+    "property": "mod.remove-tab-x.scope",
+    "label": "Remove close button from",
+    "type": "dropdown",
+    "defaultValue": "all",
+    "options": [
+      { "label": "All tabs", "value": "all" },
+      { "label": "Pinned tabs only", "value": "pinned" }
+    ]
+  }
+]


### PR DESCRIPTION
Add a dropdown preference (all tabs vs pinned tabs only) using Zen Browser's theme preferences system.